### PR TITLE
Adds support for changing the default command at runtime

### DIFF
--- a/src/Spectre.Cli/CommandApp.cs
+++ b/src/Spectre.Cli/CommandApp.cs
@@ -28,6 +28,15 @@ namespace Spectre.Cli
         }
 
         /// <summary>
+        /// Sets the default command type.
+        /// </summary>
+        /// <param name="defaultCommand">The default command type. Must implement <see cref="ICommand"/>.</param>
+        public void SetDefaultCommand(Type defaultCommand)
+        {
+            _configurator.SetDefaultCommand(defaultCommand);
+        }
+
+        /// <summary>
         /// Configures the command line application.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
@@ -80,11 +89,6 @@ namespace Spectre.Cli
 
                 return -1;
             }
-        }
-
-        internal Configurator GetConfigurator()
-        {
-            return _configurator;
         }
 
         private static IRenderable GetRenderableErrorMessage(Exception ex, bool convert = true)

--- a/src/Spectre.Cli/CommandApp`1.cs
+++ b/src/Spectre.Cli/CommandApp`1.cs
@@ -20,7 +20,7 @@ namespace Spectre.Cli
         public CommandApp(ITypeRegistrar registrar = null)
         {
             _app = new CommandApp(registrar);
-            _app.GetConfigurator().SetDefaultCommand<TDefaultCommand>();
+            _app.SetDefaultCommand(typeof(TDefaultCommand));
         }
 
         /// <summary>

--- a/src/Spectre.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Cli/Internal/Configuration/Configurator.cs
@@ -49,7 +49,15 @@ namespace Spectre.Cli.Internal.Configuration
         public void SetDefaultCommand<TDefaultCommand>()
             where TDefaultCommand : class, ICommand
         {
-            var defaultCommand = typeof(TDefaultCommand);
+            SetDefaultCommand(typeof(TDefaultCommand));
+        }
+
+        public void SetDefaultCommand(Type defaultCommand)
+        {
+            if (!typeof(ICommand).IsAssignableFrom(defaultCommand))
+            {
+                throw new ArgumentException("The default command must implement " + nameof(ICommand), nameof(defaultCommand));
+            }
 
             // Initialize the default command.
             var settingsType = ConfigurationHelper.GetSettingsType(defaultCommand);


### PR DESCRIPTION
This PR adds support for setting/changing the default command type at runtime on the non-generic `CommandApp`. I was also able to remove the `internal Configurator CommandApp.GetConfigurator()` method since it was only used to set the default command from the generic `CommandApp<T>` and now there's a more direct way to do that.