### PR TITLE
Adds command name to CommandContext

### DIFF
--- a/src/Spectre.Cli.Tests/Unit/CommandAppTests.cs
+++ b/src/Spectre.Cli.Tests/Unit/CommandAppTests.cs
@@ -472,6 +472,37 @@ namespace Spectre.Cli.Tests.Unit
         }
 
         [Fact]
+        public void Should_Set_Command_Name_In_Context()
+        {
+            // Given
+            var capturedContext = default(CommandContext);
+
+            var resolver = new FakeTypeResolver();
+            var command = new InterceptingCommand<DogSettings>((context, _) => { capturedContext = context; });
+            resolver.Register(new DogSettings());
+            resolver.Register(command);
+
+            var registrar = new FakeTypeRegistrar(resolver);
+            var app = new CommandApp(registrar);
+
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<InterceptingCommand<DogSettings>>("dog");
+                });
+            });
+
+            // When
+            var result = app.Run(new[] { "animal", "4", "dog", "12" });
+
+            // Then
+            capturedContext.ShouldNotBeNull();
+            capturedContext.Name.ShouldBe("dog");
+        }
+
+        [Fact]
         public void Should_Pass_Command_Data_In_Context()
         {
             // Given

--- a/src/Spectre.Cli/CommandContext.cs
+++ b/src/Spectre.Cli/CommandContext.cs
@@ -16,6 +16,14 @@ namespace Spectre.Cli
         public IRemainingArguments Remaining { get; }
 
         /// <summary>
+        /// Gets the name of the command.
+        /// </summary>
+        /// <value>
+        /// The name of the command.
+        /// </value>
+        public string Name { get; }
+
+        /// <summary>
         /// Gets the data that was passed to the command during registration (if any).
         /// </summary>
         /// <value>
@@ -27,10 +35,12 @@ namespace Spectre.Cli
         /// Initializes a new instance of the <see cref="CommandContext"/> class.
         /// </summary>
         /// <param name="remaining">The remaining arguments.</param>
+        /// <param name="name">The command name.</param>
         /// <param name="data">The command data.</param>
-        internal CommandContext(IRemainingArguments remaining, object data)
+        internal CommandContext(IRemainingArguments remaining, string name, object data)
         {
             Remaining = remaining;
+            Name = name;
             Data = data;
         }
     }

--- a/src/Spectre.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Cli/Internal/CommandExecutor.cs
@@ -54,7 +54,7 @@ namespace Spectre.Cli.Internal
 
             // Create the resolver and the context.
             var resolver = new TypeResolverAdapter(_registrar?.Build());
-            var context = new CommandContext(parsedResult.Remaining, leaf.Command.Data);
+            var context = new CommandContext(parsedResult.Remaining, leaf.Command.Name, leaf.Command.Data);
 
             // Execute the command tree.
             return Execute(leaf, parsedResult.Tree, context, resolver);


### PR DESCRIPTION
This adds the command name to the `CommandContext` (something else I've been wanting so I can pass the executing command name to callers so they can react to it).