### PR TITLE
Add support for optional flag values

### DIFF
--- a/samples/Advanced/Commands/BuildCommand.cs
+++ b/samples/Advanced/Commands/BuildCommand.cs
@@ -35,18 +35,24 @@ namespace Sample.Commands
                 // Pretend we're restoring packages.
                 Console.WriteLine("Restoring packages...");
             }
-            
+
             // Get the project name.
             var project = settings.Project;
             if (string.IsNullOrWhiteSpace(project))
             {
                 project = "random.csproj";
             }
-            
+
             // Pretend we're building.
             Console.WriteLine($"Building {project}...");
             await Task.Delay(1000);
             Console.WriteLine("Build completed!");
+
+            // Serve?
+            if (settings.Serve.IsSet)
+            {
+                Console.WriteLine($"Serving content on https://localhost:{settings.Serve.Value}...");
+            }
 
             // Return success.
             return 0;

--- a/samples/Advanced/Commands/BuildSettings.cs
+++ b/samples/Advanced/Commands/BuildSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Sample.Validation;
 using Spectre.Cli;
 
@@ -18,6 +18,10 @@ namespace Sample.Commands
         [CommandOption("--force-restore")]
         [Description("Forces a restore during build.")]
         public bool ForceRestore { get; set; }
+
+        [CommandOption("--serve [PORT]")]
+        [DefaultValue(8080)]
+        public FlagValue<int> Serve { get; set; }
 
         // For validating arguments together.
         public override ValidationResult Validate()

--- a/src/Spectre.Cli.Tests/Annotations/CommandOptionAttributeTests.Rendering.cs
+++ b/src/Spectre.Cli.Tests/Annotations/CommandOptionAttributeTests.Rendering.cs
@@ -178,27 +178,6 @@ namespace Spectre.Cli.Tests.Annotations
             }
         }
 
-        public sealed class TheOptionValueCannotBeOptionalMethod
-        {
-            public sealed class Settings : CommandSettings
-            {
-                [CommandOption("-f|--foo [FOO]")]
-                public string Foo { get; set; }
-            }
-
-            [Theory]
-            [EmbeddedResourceData("Spectre.Cli.Tests/Properties/Resources/Exceptions/Template/OptionValueCannotBeOptional")]
-            public void Should_Return_Correct_Text(string expected)
-            {
-                // Given, When
-                var (message, result) = Fixture.Run<Settings>();
-
-                // Then
-                message.ShouldBe("Option values cannot be optional.");
-                result.ShouldBe(expected);
-            }
-        }
-
         public sealed class TheInvalidCharacterInValueNameMethod
         {
             public sealed class Settings : CommandSettings

--- a/src/Spectre.Cli.Tests/Annotations/CommandOptionAttributeTests.cs
+++ b/src/Spectre.Cli.Tests/Annotations/CommandOptionAttributeTests.cs
@@ -8,18 +8,6 @@ namespace Spectre.Cli.Tests.Annotations
     public sealed partial class CommandOptionAttributeTests
     {
         [Fact]
-        public void Should_Throw_If_Value_Name_Is_Marked_As_Optional()
-        {
-            // Given, When
-            var result = Record.Exception(() => new CommandOptionAttribute("-o|--option [VALUE]"));
-
-            // Then
-            result.ShouldNotBe(null);
-            result.ShouldBeOfType<TemplateException>().And(exception =>
-                exception.Message.ShouldBe("Option values cannot be optional."));
-        }
-
-        [Fact]
         public void Should_Parse_Short_Name_Correctly()
         {
             // Given, When

--- a/src/Spectre.Cli.Tests/CommandAppTests.FlagValues.cs
+++ b/src/Spectre.Cli.Tests/CommandAppTests.FlagValues.cs
@@ -1,0 +1,202 @@
+using Shouldly;
+using Spectre.Cli.Exceptions;
+using Spectre.Cli.Testing;
+using Spectre.Cli.Testing.Data.Commands;
+using Spectre.Cli.Testing.Fakes;
+using Xunit;
+
+using DefaultValue = System.ComponentModel.DefaultValueAttribute;
+
+namespace Spectre.Cli.Tests
+{
+    public sealed partial class CommandAppTests
+    {
+        public sealed class FlagValues
+        {
+            private sealed class Settings : CommandSettings
+            {
+                [CommandOption("--serve [PORT]")]
+                public FlagValue<int> Serve { get; set; }
+            }
+
+            private sealed class SettingsWithNullableValueType : CommandSettings
+            {
+                [CommandOption("--serve [PORT]")]
+                public FlagValue<int?> Serve { get; set; }
+            }
+
+            private sealed class SettingsWithOptionalOptionButNoFlagValue : CommandSettings
+            {
+                [CommandOption("--serve [PORT]")]
+                public int Serve { get; set; }
+            }
+
+            private sealed class SettingsWithDefaultValue : CommandSettings
+            {
+                [CommandOption("--serve [PORT]")]
+                [DefaultValue(987)]
+                public FlagValue<int> Serve { get; set; }
+            }
+
+            [Fact]
+            public void Should_Throw_If_Command_Option_Value_Is_Optional_But_Type_Is_Not_A_Flag_Value()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new SettingsWithOptionalOptionButNoFlagValue();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<SettingsWithOptionalOptionButNoFlagValue>>("foo");
+                });
+
+                // When
+                var result = Record.Exception(() => app.Run(new[] { "foo", "--serve", "123" }));
+
+                // Then
+                result.ShouldBeOfType<ConfigurationException>().And(ex =>
+                {
+                    ex.Message.ShouldBe("The option 'serve' has an optional value but does not implement IOptionalValue.");
+                });
+            }
+
+            [Fact]
+            public void Should_Set_Flag_And_Value_If_Both_Were_Provided()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new Settings();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<Settings>>("foo");
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "foo", "--serve", "123"
+                });
+
+                // Then
+                result.ShouldBe(0);
+                settings.Serve.IsSet.ShouldBeTrue();
+                settings.Serve.Value.ShouldBe(123);
+            }
+
+            [Fact]
+            public void Should_Only_Set_Flag_If_No_Value_Was_Provided()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new Settings();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<Settings>>("foo");
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "foo", "--serve"
+                });
+
+                // Then
+                result.ShouldBe(0);
+                settings.Serve.IsSet.ShouldBeTrue();
+                settings.Serve.Value.ShouldBe(0);
+            }
+
+            [Fact]
+            public void Should_Set_Value_To_Default_Value_If_None_Was_Explicitly_Set()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new SettingsWithDefaultValue();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<SettingsWithDefaultValue>>("foo");
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "foo", "--serve"
+                });
+
+                // Then
+                result.ShouldBe(0);
+                settings.Serve.IsSet.ShouldBeTrue();
+                settings.Serve.Value.ShouldBe(987);
+            }
+
+            [Fact]
+            public void Should_Create_Unset_Instance_If_Flag_Was_Not_Set()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new Settings();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<Settings>>("foo");
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "foo"
+                });
+
+                // Then
+                result.ShouldBe(0);
+                settings.Serve.IsSet.ShouldBeFalse();
+                settings.Serve.Value.ShouldBe(0);
+            }
+
+            [Fact]
+            public void Should_Create_Unset_Instance_With_Null_For_Nullable_Value_Type_If_Flag_Was_Not_Set()
+            {
+                // Given
+                var resolver = new FakeTypeResolver();
+                var settings = new SettingsWithNullableValueType();
+                resolver.Register(settings);
+
+                var app = new CommandApp(new FakeTypeRegistrar(resolver));
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                    config.AddCommand<GenericCommand<SettingsWithNullableValueType>>("foo");
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "foo"
+                });
+
+                // Then
+                result.ShouldBe(0);
+                settings.Serve.IsSet.ShouldBeFalse();
+                settings.Serve.Value.ShouldBeNull();
+            }
+        }
+    }
+}

--- a/src/Spectre.Cli/Annotations/CommandOptionAttribute.cs
+++ b/src/Spectre.Cli/Annotations/CommandOptionAttribute.cs
@@ -32,6 +32,11 @@ namespace Spectre.Cli
         public string? ValueName { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the value is optional.
+        /// </summary>
+        public bool ValueIsOptional { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CommandOptionAttribute"/> class.
         /// </summary>
         /// <param name="template">The option template.</param>
@@ -49,6 +54,7 @@ namespace Spectre.Cli
             LongNames = result.LongNames;
             ShortNames = result.ShortNames;
             ValueName = result.Value;
+            ValueIsOptional = result.ValueIsOptional;
         }
 
         internal bool IsMatch(string name)

--- a/src/Spectre.Cli/Exceptions/ConfigurationException.cs
+++ b/src/Spectre.Cli/Exceptions/ConfigurationException.cs
@@ -53,9 +53,14 @@ namespace Spectre.Cli.Exceptions
             throw new ConfigurationException($"The command '{command.Name}' specifies more than one vector argument.");
         }
 
-        internal static Exception VectorArgumentNotSpecifiedLast(CommandInfo command)
+        internal static ConfigurationException VectorArgumentNotSpecifiedLast(CommandInfo command)
         {
             throw new ConfigurationException($"The command '{command.Name}' specifies an argument vector that is not the last argument.");
+        }
+
+        internal static ConfigurationException OptionalOptionValueMustBeFlagWithValue(CommandInfo command, CommandOption option)
+        {
+            return new ConfigurationException($"The option '{option.GetOptionName()}' has an optional value but does not implement IOptionalValue.");
         }
     }
 }

--- a/src/Spectre.Cli/Exceptions/TemplateException.cs
+++ b/src/Spectre.Cli/Exceptions/TemplateException.cs
@@ -124,13 +124,6 @@ namespace Spectre.Cli.Exceptions
                 "Too many option values.");
         }
 
-        internal static TemplateException OptionValueCannotBeOptional(string template, TemplateToken token)
-        {
-            return TemplateExceptionFactory.Create(template, token,
-                "Option values cannot be optional.",
-                "Must be required.");
-        }
-
         internal static TemplateException InvalidCharacterInValueName(string template, TemplateToken token, char character)
         {
             // Rewrite the token to point to the invalid character instead of the whole value.

--- a/src/Spectre.Cli/FlagValue.cs
+++ b/src/Spectre.Cli/FlagValue.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Spectre.Cli
+{
+    /// <summary>
+    /// Implementation of a flag with an optional value.
+    /// </summary>
+    /// <typeparam name="T">The flag's element type.</typeparam>
+    public sealed class FlagValue<T> : IFlagValue
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the flag was set or not.
+        /// </summary>
+        public bool IsSet { get; set; }
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        /// <summary>
+        /// Gets or sets the flag's value.
+        /// </summary>
+        public T Value { get; set; }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+
+        Type IFlagValue.Type => typeof(T);
+
+        object? IFlagValue.Value
+        {
+            get => Value;
+            set
+            {
+#pragma warning disable CS8601 // Possible null reference assignment.
+                Value = (T)value;
+#pragma warning restore CS8601 // Possible null reference assignment.
+            }
+        }
+    }
+}

--- a/src/Spectre.Cli/IFlagValue.cs
+++ b/src/Spectre.Cli/IFlagValue.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Spectre.Cli
+{
+    /// <summary>
+    /// Represents a flag with an optional value.
+    /// </summary>
+    public interface IFlagValue
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the flag was set or not.
+        /// </summary>
+        bool IsSet { get; set; }
+
+        /// <summary>
+        /// Gets the flag's element type.
+        /// </summary>
+        Type Type { get; }
+
+        /// <summary>
+        /// Gets or sets the flag's value.
+        /// </summary>
+        object? Value { get; set; }
+    }
+}

--- a/src/Spectre.Cli/Internal/Configuration/TemplateParser.cs
+++ b/src/Spectre.Cli/Internal/Configuration/TemplateParser.cs
@@ -22,6 +22,7 @@ namespace Spectre.Cli.Internal.Configuration
             public List<string> LongNames { get; set; }
             public List<string> ShortNames { get; set; }
             public string? Value { get; set; }
+            public bool ValueIsOptional { get; set; }
 
             public OptionResult()
             {
@@ -70,6 +71,7 @@ namespace Spectre.Cli.Internal.Configuration
         public static OptionResult ParseOptionTemplate(string template)
         {
             var result = new OptionResult();
+
             foreach (var token in TemplateTokenizer.Tokenize(template))
             {
                 if (token.TokenKind == TemplateToken.Kind.LongName || token.TokenKind == TemplateToken.Kind.ShortName)
@@ -117,10 +119,6 @@ namespace Spectre.Cli.Internal.Configuration
                     {
                         throw TemplateException.MultipleOptionValuesAreNotSupported(template, token);
                     }
-                    if (token.TokenKind == TemplateToken.Kind.OptionalValue)
-                    {
-                        throw TemplateException.OptionValueCannotBeOptional(template, token);
-                    }
 
                     foreach (var character in token.Value)
                     {
@@ -131,6 +129,7 @@ namespace Spectre.Cli.Internal.Configuration
                     }
 
                     result.Value = token.Value;
+                    result.ValueIsOptional = token.TokenKind == TemplateToken.Kind.OptionalValue;
                 }
             }
 

--- a/src/Spectre.Cli/Internal/Modelling/CommandModelBuilder.cs
+++ b/src/Spectre.Cli/Internal/Modelling/CommandModelBuilder.cs
@@ -133,7 +133,6 @@ namespace Spectre.Cli.Internal.Modelling
                                 // Do we allow it to exist on this command as well?
                                 if (command.AllowParentOption(option))
                                 {
-                                    option.Required = false;
                                     option.IsShadowed = true;
                                     parameters.Add(option);
                                 }
@@ -185,7 +184,7 @@ namespace Spectre.Cli.Internal.Modelling
             var validators = property.GetCustomAttributes<ParameterValidationAttribute>(true);
             var defaultValue = property.GetCustomAttribute<DefaultValueAttribute>();
 
-            var kind = GetParameterKind(property.PropertyType);
+            var kind = GetOptionKind(property.PropertyType, attribute);
 
             if (defaultValue == null && property.PropertyType == typeof(bool))
             {
@@ -194,7 +193,7 @@ namespace Spectre.Cli.Internal.Modelling
 
             return new CommandOption(property.PropertyType, kind,
                 property, description?.Description, converter,
-                attribute, validators, defaultValue);
+                attribute, validators, defaultValue, attribute.ValueIsOptional);
         }
 
         private static CommandArgument BuildArgumentParameter(PropertyInfo property, CommandArgumentAttribute attribute)
@@ -207,6 +206,15 @@ namespace Spectre.Cli.Internal.Modelling
 
             return new CommandArgument(property.PropertyType, kind,
                 property, description?.Description, converter, attribute, validators);
+        }
+
+        private static ParameterKind GetOptionKind(Type type, CommandOptionAttribute attribute)
+        {
+            if (attribute.ValueIsOptional)
+            {
+                return ParameterKind.FlagWithValue;
+            }
+            return GetParameterKind(type);
         }
 
         private static ParameterKind GetParameterKind(Type type)

--- a/src/Spectre.Cli/Internal/Modelling/CommandModelValidator.cs
+++ b/src/Spectre.Cli/Internal/Modelling/CommandModelValidator.cs
@@ -41,10 +41,10 @@ namespace Spectre.Cli.Internal.Modelling
         private static void Validate(CommandInfo command)
         {
             // Get duplicate options for command.
-            var options = GetDuplicates(command);
-            if (options.Length > 0)
+            var duplicateOptions = GetDuplicates(command);
+            if (duplicateOptions.Length > 0)
             {
-                throw ConfigurationException.DuplicateOption(command, options);
+                throw ConfigurationException.DuplicateOption(command, duplicateOptions);
             }
 
             // No children?
@@ -67,6 +67,16 @@ namespace Spectre.Cli.Internal.Modelling
                 if (arguments.Last().ParameterKind != ParameterKind.Vector)
                 {
                     throw ConfigurationException.VectorArgumentNotSpecifiedLast(command);
+                }
+            }
+
+            // Optional options that are not flags?
+            var options = command.Parameters.OfType<CommandOption>();
+            foreach (var option in options)
+            {
+                if (option.ParameterKind == ParameterKind.FlagWithValue && !option.IsFlagValue())
+                {
+                    throw ConfigurationException.OptionalOptionValueMustBeFlagWithValue(command, option);
                 }
             }
 

--- a/src/Spectre.Cli/Internal/Modelling/CommandOption.cs
+++ b/src/Spectre.Cli/Internal/Modelling/CommandOption.cs
@@ -11,18 +11,20 @@ namespace Spectre.Cli.Internal.Modelling
         public IReadOnlyList<string> ShortNames { get; }
         public string? ValueName { get; }
         public DefaultValueAttribute? DefaultValue { get; }
+        public bool ValueIsOptional { get; }
         public bool IsShadowed { get; set; }
 
         public CommandOption(
             Type parameterType, ParameterKind parameterKind, PropertyInfo property, string? description,
             TypeConverterAttribute? converter, CommandOptionAttribute optionAttribute,
-            IEnumerable<ParameterValidationAttribute> validators, DefaultValueAttribute? defaultValue)
+            IEnumerable<ParameterValidationAttribute> validators, DefaultValueAttribute? defaultValue, bool valueIsOptional)
                 : base(parameterType, parameterKind, property, description, converter, validators, false)
         {
             LongNames = optionAttribute.LongNames;
             ShortNames = optionAttribute.ShortNames;
             ValueName = optionAttribute.ValueName;
             DefaultValue = defaultValue;
+            ValueIsOptional = valueIsOptional;
         }
 
         public string GetOptionName()

--- a/src/Spectre.Cli/Internal/Modelling/ParameterKind.cs
+++ b/src/Spectre.Cli/Internal/Modelling/ParameterKind.cs
@@ -6,9 +6,11 @@ namespace Spectre.Cli.Internal.Modelling
     {
         [Description("flag")]
         Flag = 0,
+        [Description("flagvalue")]
+        FlagWithValue = 1,
         [Description("scalar")]
-        Scalar = 1,
+        Scalar = 2,
         [Description("vector")]
-        Vector = 2
+        Vector = 3
     }
 }

--- a/src/Spectre.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -369,14 +369,19 @@ namespace Spectre.Cli.Internal.Parsing
                     }
                     else
                     {
-                        switch (parameter)
+                        if (parameter is CommandOption option)
                         {
-                            case CommandOption option:
-                                throw ParseException.OptionHasNoValue(context.Arguments, token, option);
-                            default:
-                                // This should not happen at all. If it does, it's because we've added a new
-                                // option type which isn't a CommandOption for some reason.
-                                throw new InvalidOperationException($"Found invalid parameter type '{parameter.GetType().FullName}'.");
+                            if (parameter.IsFlagValue())
+                            {
+                                return null;
+                            }
+                            throw ParseException.OptionHasNoValue(context.Arguments, token, option);
+                        }
+                        else
+                        {
+                            // This should not happen at all. If it does, it's because we've added a new
+                            // option type which isn't a CommandOption for some reason.
+                            throw new InvalidOperationException($"Found invalid parameter type '{parameter.GetType().FullName}'.");
                         }
                     }
                 }


### PR DESCRIPTION
Add support for optional flag values.

```csharp
public sealed class MySettings : CommandSettings
{
    [CommandOption("--foo [VALUE]")]
    [TypeConverter(typeof(FooConverter))]
    public FlagValue<Foo> UseFoo { get; set; }

    [CommandOption("--serve [PORT]")]
    [DefaultValue(8080)]
    public FlagValue<int> Serve { get; set; }
}
```