### PR TITLE
GH94: Change ParameterValidation Validate to include propertyName

### DIFF
--- a/samples/Advanced/Validation/ValidateProjectNameAttribute.cs
+++ b/samples/Advanced/Validation/ValidateProjectNameAttribute.cs
@@ -1,4 +1,4 @@
-﻿using Spectre.Cli;
+using Spectre.Cli;
 
 namespace Sample.Validation
 {
@@ -9,16 +9,16 @@ namespace Sample.Validation
         {
         }
 
-        public override ValidationResult Validate(object value)
+        public override ValidationResult Validate(object value, string propertyName)
         {
             if (!(value is string project))
             {
-                return ValidationResult.Error("Package must be a string.");
+                return ValidationResult.Error($"Package must be a string ({propertyName}).");
             }
 
             if (!project.EndsWith(".csproj"))
             {
-                return ValidationResult.Error("Provided project is not a csproj file.");
+                return ValidationResult.Error($"Provided project is not a csproj file ({propertyName}).");
             }
 
             return ValidationResult.Success();

--- a/src/Spectre.Cli.Testing/Data/Validators/EvenNumberValidatorAttribute.cs
+++ b/src/Spectre.Cli.Testing/Data/Validators/EvenNumberValidatorAttribute.cs
@@ -10,7 +10,7 @@ namespace Spectre.Cli.Testing.Data.Validators
         {
         }
 
-        public override ValidationResult Validate(object value)
+        public override ValidationResult Validate(object value, string propertyName)
         {
             if (value is int integer)
             {
@@ -19,10 +19,10 @@ namespace Spectre.Cli.Testing.Data.Validators
                     return ValidationResult.Success();
                 }
 
-                return ValidationResult.Error("Number is not even.");
+                return ValidationResult.Error($"Number is not even ({propertyName}).");
             }
 
-            throw new InvalidOperationException("Parameter is not a number.");
+            throw new InvalidOperationException($"Parameter is not a number ({propertyName}).");
         }
     }
 }

--- a/src/Spectre.Cli.Testing/Data/Validators/PositiveNumberValidatorAttribute.cs
+++ b/src/Spectre.Cli.Testing/Data/Validators/PositiveNumberValidatorAttribute.cs
@@ -10,7 +10,7 @@ namespace Spectre.Cli.Testing.Data.Validators
         {
         }
 
-        public override ValidationResult Validate(object value)
+        public override ValidationResult Validate(object value, string propertyName)
         {
             if (value is int integer)
             {
@@ -19,10 +19,10 @@ namespace Spectre.Cli.Testing.Data.Validators
                     return ValidationResult.Success();
                 }
 
-                return ValidationResult.Error("Number is not greater than 0.");
+                return ValidationResult.Error($"Number is not greater than 0 ({propertyName}).");
             }
 
-            throw new InvalidOperationException("Parameter is not a number.");
+            throw new InvalidOperationException($"Parameter is not a number ({propertyName}).");
         }
     }
 }

--- a/src/Spectre.Cli/Annotations/ParameterValidationAttribute.cs
+++ b/src/Spectre.Cli/Annotations/ParameterValidationAttribute.cs
@@ -29,7 +29,8 @@ namespace Spectre.Cli
         /// Validates the parameter value.
         /// </summary>
         /// <param name="value">The parameter value.</param>
+        /// <param name="propertyName">The property name.</param>
         /// <returns>The validation result.</returns>
-        public abstract ValidationResult Validate(object? value);
+        public abstract ValidationResult Validate(object? value, string propertyName);
     }
 }

--- a/src/Spectre.Cli/Internal/CommandBinder.cs
+++ b/src/Spectre.Cli/Internal/CommandBinder.cs
@@ -139,7 +139,7 @@ namespace Spectre.Cli.Internal
             var assignedValue = parameter.Get(settings);
             foreach (var validator in parameter.Validators)
             {
-                var validationResult = validator.Validate(assignedValue);
+                var validationResult = validator.Validate(assignedValue, parameter.Property.Name);
                 if (!validationResult.Successful)
                 {
                     // If there is a error message specified in the parameter validator attribute,


### PR DESCRIPTION
* fixes #94

Realize this is a breaking change, if you don't want that could change `ParameterValidationAttribute : Attribute` to something like `ParameterValidationAttribute : NamedParameterValidationAttribute`.